### PR TITLE
Add sample implementations for the decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,40 @@ class Bork {
 @frozen class Foo {
   @configurable(false) @enumerable(true) method() {}
 }
+function frozen(constructor, parent, elements) {
+  return {
+    constructor,
+    elements,
+    finisher(constructor) {
+      Object.freeze(constructor.prototype)
+      Object.freeze(constructor)
+    }
+  }
+}
+function configurable(configurable) {
+  return decorator;
+  function decorator(previousDescriptor) {
+    return {
+      ...previousDescriptor,
+      descriptor: {
+        ...previousDescriptor.descriptor,
+        configurable
+      }
+    }
+  }
+}
+function enumerable(enumerable) {
+  return decorator;
+  function decorator(previousDescriptor) {
+    return {
+      ...previousDescriptor,
+      descriptor: {
+        ...previousDescriptor.descriptor,
+        enumerable
+      }
+    }
+  }
+}
 ```
 </details>
 


### PR DESCRIPTION
This is what I could gather from reading the spec, and assuming an implementation of the current spec exists, should produce the expected result... assuming I am not misreading things.

I found a few issues that made this challenging, though. See https://github.com/tc39/proposal-decorators/issues/36, https://github.com/tc39/proposal-decorators/issues/37, https://github.com/tc39/proposal-decorators/issues/38, https://github.com/tc39/proposal-decorators/issues/16.